### PR TITLE
docs: rewrite README with senior DevOps documentation standards

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,104 +1,197 @@
 # Docker DuoAuthProxy
 
 [![Docker Image Publish](https://github.com/ict-solutions-dev/docker-duoauthproxy/actions/workflows/docker.yml/badge.svg)](https://github.com/ict-solutions-dev/docker-duoauthproxy/actions/workflows/docker.yml)
+[![GitHub release](https://img.shields.io/github/v/release/ict-solutions-dev/docker-duoauthproxy)](https://github.com/ict-solutions-dev/docker-duoauthproxy/releases)
 
-Docker image for Duo Security Authentication Proxy with RADIUS support.
+Production-ready Docker image for [Duo Security Authentication Proxy](https://duo.com/docs/authproxy-reference) with RADIUS support. Built for `linux/amd64` and `linux/arm64` on Ubuntu 24.04.
 
-## Environment Variables
+## Quick Start
 
-### Required Variables
+```bash
+docker run -d \
+  --name duoauthproxy \
+  -p 1812:1812/udp \
+  -e RADIUS_HOST=10.10.10.2 \
+  -e RADIUS_SECRET=radiussecret \
+  -e DUO_IKEY=DIXXXXXXXXXXXXXXXXXX \
+  -e DUO_SKEY=YourSecretKeyHere \
+  -e DUO_API_HOST=api-XXXXXXXX.duosecurity.com \
+  -e RADIUS_CLIENT_IP_1=192.168.1.10 \
+  -e RADIUS_CLIENT_SECRET_1=clientsecret \
+  ghcr.io/ict-solutions-dev/duoauthproxy:edge-duo6.5.2
+```
+
+## Docker Compose
+
+```yaml
+services:
+  duoauthproxy:
+    image: ghcr.io/ict-solutions-dev/duoauthproxy:1.1.0-duo6.5.2
+    container_name: duoauthproxy
+    restart: unless-stopped
+    ports:
+      - "1812:1812/udp"
+    environment:
+      RADIUS_HOST: 10.10.10.2
+      RADIUS_SECRET_FILE: /run/secrets/radius_secret
+      DUO_IKEY_FILE: /run/secrets/duo_ikey
+      DUO_SKEY_FILE: /run/secrets/duo_skey
+      DUO_API_HOST: api-XXXXXXXX.duosecurity.com
+      RADIUS_CLIENT_IP_1: 192.168.1.10
+      RADIUS_CLIENT_SECRET_FILE: /run/secrets/radius_client_secret
+      RADIUS_FAILMODE: safe
+    secrets:
+      - radius_secret
+      - duo_ikey
+      - duo_skey
+      - radius_client_secret
+    volumes:
+      - duoauthproxy-logs:/opt/duoauthproxy/log
+
+secrets:
+  radius_secret:
+    file: ./secrets/radius_secret.txt
+  duo_ikey:
+    file: ./secrets/duo_ikey.txt
+  duo_skey:
+    file: ./secrets/duo_skey.txt
+  radius_client_secret:
+    file: ./secrets/radius_client_secret.txt
+
+volumes:
+  duoauthproxy-logs:
+```
+
+## Configuration
+
+### Required Environment Variables
 
 | Variable | Description |
-|----------|-------------|
-| `RADIUS_HOST` | Primary RADIUS server hostname/IP |
+| --- | --- |
+| `RADIUS_HOST` | Primary RADIUS server hostname or IP |
 | `RADIUS_SECRET` | RADIUS server shared secret |
 | `DUO_IKEY` | Duo integration key |
 | `DUO_SKEY` | Duo secret key |
-| `DUO_API_HOST` | Duo API hostname |
-| `RADIUS_CLIENT_IP_1` | RADIUS client IP address |
-| `RADIUS_CLIENT_SECRET_1` | RADIUS client shared secret |
+| `DUO_API_HOST` | Duo API hostname (e.g. `api-XXXXXXXX.duosecurity.com`) |
+| `RADIUS_CLIENT_IP_1` | First RADIUS client IP address |
+| `RADIUS_CLIENT_SECRET_1` | First RADIUS client shared secret |
 
-### Optional Variables
+### Optional Environment Variables
 
-| Variable | Description | Default |
-|----------|-------------|---------|
-| `RADIUS_PORT` | RADIUS server port | `1812` |
-| `RADIUS_SERVER_PORT` | Local RADIUS server port | `1812` |
-| `RADIUS_CLIENT_TYPE` | Client type (`radius_client`, `ad_client`, `duo_only_client`) | `radius_client` |
-| `RADIUS_FAILMODE` | Failmode (`safe`, `secure`) | `safe` |
-| `RADIUS_PASS_THROUGH_ALL` | Pass through all attributes | `false` |
-| `RADIUS_PASS_THROUGH_ATTRS` | Comma-separated list of attributes to pass through | - |
+| Variable | Default | Description |
+| --- | --- | --- |
+| `RADIUS_PORT` | `1812` | Upstream RADIUS server port |
+| `RADIUS_SERVER_PORT` | `1812` | Local RADIUS listener port |
+| `RADIUS_CLIENT_TYPE` | `radius_client` | Auth client type — `radius_client`, `ad_client`, or `duo_only_client` |
+| `RADIUS_FAILMODE` | `safe` | Behavior when Duo is unreachable — `safe` (allow) or `secure` (deny) |
+| `RADIUS_PASS_THROUGH_ALL` | `false` | Forward all RADIUS attributes to the client |
+| `RADIUS_PASS_THROUGH_ATTRS` | — | Comma-separated attribute names to forward (e.g. `Framed-IP-Address,Reply-Message`) |
 
-### Additional RADIUS Servers
+### Multiple RADIUS Servers (up to 6)
 
-You can configure up to 5 additional RADIUS servers using:
-
-| Variable | Description |
-|----------|-------------|
-| `RADIUS_HOST_2` to `RADIUS_HOST_6` | Additional RADIUS server hostnames |
-| `RADIUS_PORT_2` to `RADIUS_PORT_6` | Ports for additional servers (defaults to 1812) |
-
-### Additional RADIUS Clients
-
-Support for multiple RADIUS clients:
+Configure additional upstream RADIUS servers using sequentially numbered variables:
 
 | Variable | Description |
-|----------|-------------|
-| `RADIUS_CLIENT_IP_2` to `RADIUS_CLIENT_IP_6` | Additional client IPs |
-| `RADIUS_CLIENT_SECRET_2` to `RADIUS_CLIENT_SECRET_6` | Secrets for additional clients |
+| --- | --- |
+| `RADIUS_HOST_2` … `RADIUS_HOST_6` | Additional RADIUS server hostnames/IPs |
+| `RADIUS_PORT_2` … `RADIUS_PORT_6` | Ports for additional servers (default: `1812`) |
 
-## Usage
+> **Note:** Hosts must be defined sequentially — you cannot define `RADIUS_HOST_4` without `RADIUS_HOST_2` and `RADIUS_HOST_3`.
 
-Basic docker run command:
+### Multiple RADIUS Clients (up to 6)
 
-```console
-docker run -d \
-  -e RADIUS_HOST=10.10.10.2 \
-  -e RADIUS_SECRET=radiussecret \
-  -e DUO_IKEY=YOUR_IKEY \
-  -e DUO_SKEY=YOUR_SKEY \
-  -e DUO_API_HOST=api-xyz.duosecurity.com \
-  -e RADIUS_CLIENT_IP_1=192.168.1.10 \
-  -e RADIUS_CLIENT_SECRET_1=clientsecret \
-  ghcr.io/ict-solutions-dev/duoauthproxy:edge-duo6.4.2
+| Variable | Description |
+| --- | --- |
+| `RADIUS_CLIENT_IP_2` … `RADIUS_CLIENT_IP_6` | Additional client IPs |
+| `RADIUS_CLIENT_SECRET_2` … `RADIUS_CLIENT_SECRET_6` | Corresponding client secrets |
+
+### Docker Secrets Support
+
+Every environment variable that contains sensitive data supports the `_FILE` suffix pattern for use with Docker secrets or mounted files:
+
+```bash
+# Instead of passing the secret directly:
+-e RADIUS_SECRET=mysecret
+
+# Mount a file and reference it:
+-e RADIUS_SECRET_FILE=/run/secrets/radius_secret
 ```
 
-# Version Management
+If both `VAR` and `VAR_FILE` are set, the container will exit with an error.
 
-## Image Versioning Strategy
+## Exposed Ports
 
-Images are built automatically using the following schema:
-- `edge-duo{VERSION}` - Development builds from `develop` branch
-- `{RELEASE}-duo{VERSION}` - Release builds from tags (e.g. `v1.0.0-duo6.4.2`)
+| Port | Protocol | Purpose |
+| --- | --- | --- |
+| `1812–1818` | UDP | RADIUS authentication |
+| `18120` | UDP | Duo Authentication Proxy |
+| `636` | TCP | LDAPS |
+| `389` | TCP | LDAP |
 
-Where:
-- `{RELEASE}` comes from Git tags (e.g. `v1.0.0`)
-- `{VERSION}` comes from `SUPPORTED_VERSIONS.md`
+## Volumes
 
-## Supported Versions
+| Path | Purpose |
+| --- | --- |
+| `/opt/duoauthproxy/conf/` | Configuration directory (generated at startup) |
+| `/opt/duoauthproxy/log/` | Application logs |
 
-Supported DuoAuthProxy versions are maintained in `SUPPORTED_VERSIONS.md`. Images are automatically built for each listed version.
+## How It Works
+
+The entrypoint script ([`assets/01-init.sh`](assets/01-init.sh)) performs the following on container startup:
+
+1. **Secret file resolution** — reads `*_FILE` environment variables from mounted files
+2. **Input validation** — checks required variables, sequential host ordering, valid client types and failmodes
+3. **Config generation** — writes `/opt/duoauthproxy/conf/authproxy.cfg` from environment variables
+4. **Connectivity test** — runs `authproxy_connectivity_tool` to verify Duo API reachability
+5. **Startup** — launches the authentication proxy daemon via `exec`
+
+Secrets are redacted in the startup log output.
 
 ## Image Tags
 
-Examples:
-```console
-ghcr.io/ict-solutions-dev/duoauthproxy:edge-duo6.4.2     # Latest development build
-ghcr.io/ict-solutions-dev/duoauthproxy:1.0.0-duo6.4.2    # Release 1.0.0 with Duo 6.4.2
+Images are published to [GitHub Container Registry](https://github.com/ict-solutions-dev/docker-duoauthproxy/pkgs/container/duoauthproxy).
+
+| Tag Pattern | Source | Example |
+| --- | --- | --- |
+| `edge-duo{VERSION}` | `develop` branch | `edge-duo6.5.2` |
+| `{RELEASE}-duo{VERSION}` | Git tag (`v*`) | `1.1.0-duo6.5.2` |
+
+```bash
+# Development (latest from develop branch)
+docker pull ghcr.io/ict-solutions-dev/duoauthproxy:edge-duo6.5.2
+
+# Production release
+docker pull ghcr.io/ict-solutions-dev/duoauthproxy:1.1.0-duo6.5.2
 ```
 
-## Build Process
+Supported Duo Authentication Proxy versions are listed in [`SUPPORTED_VERSIONS.md`](SUPPORTED_VERSIONS.md).
 
-1. GitHub Actions trigger on:
-   - Push to `develop` branch
-   - New version tags (`v*`)
-   - Manual workflow dispatch
+## CI/CD Pipeline
 
-2. Build matrix is created from:
-   - All versions in  SUPPORTED_VERSIONS.md
-   - Or specific version via manual trigger
+The [GitHub Actions workflow](.github/workflows/docker.yml) runs on push to `develop`, version tags (`v*`), and manual dispatch.
 
-3. For each version:
-   - Builds Docker image with specified Duo version
-   - Tags image with appropriate version scheme
-   - Pushes to GitHub Container Registry
+For each supported Duo version the pipeline:
+
+1. **Lints** the Dockerfile with [hadolint](https://github.com/hadolint/hadolint)
+2. **Builds** multi-arch images (`linux/amd64`, `linux/arm64`) using Docker Buildx
+3. **Pushes** to GitHub Container Registry
+4. **Scans** for vulnerabilities with [Trivy](https://github.com/aquasecurity/trivy) (results uploaded to Security tab)
+5. **Generates** SBOM in SPDX format via [Anchore](https://github.com/anchore/sbom-action)
+6. **Attests** build provenance with [GitHub Attestations](https://github.com/actions/attest-build-provenance)
+
+## Security
+
+- Container runs as non-root user `duo` (UID/GID `35505`)
+- Trivy vulnerability scanning on every build
+- SBOM generation for supply chain transparency
+- Build provenance attestation via Sigstore
+- Docker secrets support to avoid plaintext credentials
+- Dependabot enabled for Docker base image and GitHub Actions updates
+
+## Contributing
+
+This repository enforces [Conventional Commits](https://www.conventionalcommits.org/) for PR titles via [prlint](https://github.com/ewolfe/prlint). Valid prefixes: `feat`, `fix`, `chore`, `docs`, `perf`, `refactor`, `style`, `test`, `lang`.
+
+## License
+
+See repository for license details.

--- a/SUPPORTED_VERSIONS.md
+++ b/SUPPORTED_VERSIONS.md
@@ -1,5 +1,11 @@
 # Supported Duo Authentication Proxy Versions
 
+This file drives the CI/CD build matrix. Each version listed below triggers a separate Docker image build in the [GitHub Actions workflow](.github/workflows/docker.yml).
+
+To add a new version, append it to the list below and push to `develop`. The pipeline will automatically build and publish images for all listed versions.
+
+> **Format:** One version per line, prefixed with `- `. The workflow parses this file directly.
+
 - 6.4.2
 - 6.5.0
 - 6.5.1


### PR DESCRIPTION
## Summary

- Complete README rewrite with production-grade DevOps documentation
- Added Docker Compose example with Docker secrets integration
- Documented entrypoint script behavior (secret resolution, validation, config generation, connectivity test)
- Added CI/CD pipeline breakdown (hadolint, multi-arch build, Trivy, SBOM, attestation)
- Documented exposed ports, volumes, security features, and contributing guidelines
- Added badges for GitHub release version
- Improved `SUPPORTED_VERSIONS.md` with context on how it drives the build matrix