### PR TITLE
feat: add Duo Authentication Proxy 6.6.0 to build matrix

### DIFF
--- a/SUPPORTED_VERSIONS.md
+++ b/SUPPORTED_VERSIONS.md
@@ -10,3 +10,4 @@ To add a new version, append it to the list below and push to `develop`. The pip
 - 6.5.0
 - 6.5.1
 - 6.5.2
+- 6.6.0


### PR DESCRIPTION
## Summary

- Add Duo Authentication Proxy **6.6.0** (released November 12, 2025) to `SUPPORTED_VERSIONS.md`
- Pipeline will build `edge-duo6.6.0` images automatically

## What's new in Duo 6.6.0

- **RadSec (RADIUS over TLS)** beta support in `radius_client` and `radius_server_*` sections
- **Python 3.12.12** upgrade with CVE fixes

RadSec implementation tracked separately in #35.