### PR TITLE
feat: add DNS hostname support for radius_client host parameter

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -61,6 +61,7 @@ jobs:
           fi
 
           echo "tags=${IMAGE_ID}:${RELEASE_VERSION}-duo${DUO_VERSION}" >> "$GITHUB_OUTPUT"
+          echo "tags_dns=${IMAGE_ID}:${RELEASE_VERSION}-duo${DUO_VERSION}-dns" >> "$GITHUB_OUTPUT"
 
       - name: Build and push
         id: build
@@ -76,6 +77,21 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
+      - name: Build and push (DNS variant)
+        id: build-dns
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: ./Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.prep.outputs.tags_dns }}
+          build-args: |
+            DUO_VERSION=${{ env.DUO_VERSION }}
+            ENABLE_DNS_PATCH=true
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
       - name: Run Trivy vulnerability scanner
         if: github.event_name != 'pull_request' && success()
         uses: aquasecurity/trivy-action@0.35.0
@@ -84,11 +100,27 @@ jobs:
           format: 'sarif'
           output: 'trivy-results.sarif'
 
+      - name: Run Trivy vulnerability scanner (DNS variant)
+        if: github.event_name != 'pull_request' && success()
+        uses: aquasecurity/trivy-action@0.35.0
+        with:
+          image-ref: ${{ steps.prep.outputs.tags_dns }}
+          format: 'sarif'
+          output: 'trivy-results-dns.sarif'
+
       - name: Upload Trivy scan results to GitHub Security tab
         if: github.event_name != 'pull_request' && success()
         uses: github/codeql-action/upload-sarif@v4
         with:
           sarif_file: 'trivy-results.sarif'
+          category: standard
+
+      - name: Upload Trivy scan results to GitHub Security tab (DNS variant)
+        if: github.event_name != 'pull_request' && success()
+        uses: github/codeql-action/upload-sarif@v4
+        with:
+          sarif_file: 'trivy-results-dns.sarif'
+          category: dns-variant
 
       - name: Generate SBOM
         if: github.event_name != 'pull_request' && success()
@@ -98,12 +130,22 @@ jobs:
           format: spdx-json
           output-file: sbom.spdx.json
 
+      - name: Generate SBOM (DNS variant)
+        if: github.event_name != 'pull_request' && success()
+        uses: anchore/sbom-action@v0.23.1
+        with:
+          image: ${{ steps.prep.outputs.tags_dns }}
+          format: spdx-json
+          output-file: sbom-dns.spdx.json
+
       - name: Upload SBOM as artifact
         if: github.event_name != 'pull_request' && success()
         uses: actions/upload-artifact@v7
         with:
           name: sbom-${{ github.run_id }}
-          path: sbom.spdx.json
+          path: |
+            sbom.spdx.json
+            sbom-dns.spdx.json
 
       - name: Attest build provenance
         if: github.event_name != 'pull_request' && success()
@@ -112,21 +154,28 @@ jobs:
           subject-name: ${{ steps.prep.outputs.tags }}
           subject-digest: ${{ steps.build.outputs.digest }}
 
+      - name: Attest build provenance (DNS variant)
+        if: github.event_name != 'pull_request' && success()
+        uses: actions/attest-build-provenance@v4
+        with:
+          subject-name: ${{ steps.prep.outputs.tags_dns }}
+          subject-digest: ${{ steps.build-dns.outputs.digest }}
+
       - name: Job Summary
         run: |
           echo "### Docker Build Summary 🐳" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "**Build Information:**" >> $GITHUB_STEP_SUMMARY
-          echo "- Tags: ${{ steps.prep.outputs.tags }}" >> $GITHUB_STEP_SUMMARY
+          echo "- Standard: \`${{ steps.prep.outputs.tags }}\`" >> $GITHUB_STEP_SUMMARY
+          echo "- DNS variant: \`${{ steps.prep.outputs.tags_dns }}\`" >> $GITHUB_STEP_SUMMARY
           echo "- DUO Version: ${{ env.DUO_VERSION }}" >> $GITHUB_STEP_SUMMARY
           echo "- Platforms: linux/amd64, linux/arm64" >> $GITHUB_STEP_SUMMARY
-          echo "- Digest: ${{ steps.build.outputs.digest }}" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "**Security & Compliance:**" >> $GITHUB_STEP_SUMMARY
           if [ "${{ github.event_name }}" != "pull_request" ]; then
-            echo "- ✅ Vulnerability scan completed" >> $GITHUB_STEP_SUMMARY
+            echo "- ✅ Vulnerability scan completed (both variants)" >> $GITHUB_STEP_SUMMARY
             echo "- ✅ SBOM generated (artifact: sbom-${{ github.run_id }})" >> $GITHUB_STEP_SUMMARY
-            echo "- ✅ Build provenance attested" >> $GITHUB_STEP_SUMMARY
+            echo "- ✅ Build provenance attested (both variants)" >> $GITHUB_STEP_SUMMARY
             echo "- ✅ Images pushed to GHCR" >> $GITHUB_STEP_SUMMARY
           else
             echo "- 🔍 Build-only mode (PR)" >> $GITHUB_STEP_SUMMARY

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,6 +37,14 @@ RUN wget --progress=dot:giga --no-check-certificate -O duoauthproxy-${DUO_VERSIO
     mv duoauthproxy-*-src duoauthproxy-src
 
 WORKDIR /tmp/duoauthproxy-src
+
+# Optional: enable DNS hostname support for [radius_client] host parameter
+ARG ENABLE_DNS_PATCH=false
+COPY assets/patch-dns-support.py /tmp/patch-dns-support.py
+RUN if [ "$ENABLE_DNS_PATCH" = "true" ]; then \
+      python3 /tmp/patch-dns-support.py /tmp/duoauthproxy-src; \
+    fi && rm /tmp/patch-dns-support.py
+
 RUN make
 
 WORKDIR /tmp/duoauthproxy-src/duoauthproxy-build

--- a/README.md
+++ b/README.md
@@ -119,6 +119,28 @@ Every environment variable that contains sensitive data supports the `_FILE` suf
 
 If both `VAR` and `VAR_FILE` are set, the container will exit with an error.
 
+## DNS Variant
+
+The standard Duo Authentication Proxy only accepts IP addresses for the `RADIUS_HOST` parameter. The `-dns` image variant patches the proxy to also accept DNS hostnames, which is useful in Docker Swarm or Compose environments where services are referenced by name.
+
+```yaml
+services:
+  duoauthproxy:
+    image: ghcr.io/ict-solutions-dev/duoauthproxy:1.2.0-duo6.6.0-dns
+    environment:
+      RADIUS_HOST: nps-server  # Docker service name instead of IP
+```
+
+The DNS variant resolves hostnames to IP addresses at container startup. The resolved IP is used for all subsequent RADIUS communication.
+
+> **Note:** DNS resolution happens once at startup. If the target service IP changes (e.g. container reschedule), the proxy container must be restarted. In Docker Swarm this is typically not an issue since service VIPs are stable.
+
+To build the DNS variant locally:
+
+```bash
+docker build --build-arg DUO_VERSION=6.6.0 --build-arg ENABLE_DNS_PATCH=true -t duoauthproxy:dns .
+```
+
 ## Exposed Ports
 
 | Port | Protocol | Purpose |
@@ -171,6 +193,8 @@ Images are published to [GitHub Container Registry](https://github.com/ict-solut
 | --- | --- | --- |
 | `edge-duo{VERSION}` | `develop` branch | `edge-duo6.6.0` |
 | `{RELEASE}-duo{VERSION}` | Git tag (`v*`) | `1.2.0-duo6.6.0` |
+| `edge-duo{VERSION}-dns` | `develop` branch (DNS variant) | `edge-duo6.6.0-dns` |
+| `{RELEASE}-duo{VERSION}-dns` | Git tag (`v*`, DNS variant) | `1.2.0-duo6.6.0-dns` |
 
 ```bash
 # Development (latest from develop branch)
@@ -178,6 +202,9 @@ docker pull ghcr.io/ict-solutions-dev/duoauthproxy:edge-duo6.6.0
 
 # Production release
 docker pull ghcr.io/ict-solutions-dev/duoauthproxy:1.2.0-duo6.6.0
+
+# DNS variant (supports hostnames in RADIUS_HOST)
+docker pull ghcr.io/ict-solutions-dev/duoauthproxy:1.2.0-duo6.6.0-dns
 ```
 
 Only the latest Duo version is actively built. Older images remain available in GHCR but are no longer rebuilt.

--- a/assets/patch-dns-support.py
+++ b/assets/patch-dns-support.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+"""
+Patch Duo Authentication Proxy to support DNS hostnames in [radius_client] host parameter.
+
+By default, Duo Auth Proxy only accepts IP addresses for the host parameter.
+This patch adds hostname resolution support so Docker service names can be used.
+
+Modifies:
+  - lib/ip_util.py: Accept valid hostnames in addition to IP addresses
+  - lib/util.py: Resolve hostnames to IP addresses in get_addr_port_pairs()
+"""
+
+import os
+import sys
+
+
+def patch_ip_util(base_path):
+    """Patch ip_util.py to accept hostnames in is_valid_single_ip()."""
+    filepath = os.path.join(
+        base_path, "pkgs/duoauthproxy/duoauthproxy/lib/ip_util.py"
+    )
+
+    with open(filepath, "r") as f:
+        content = f.read()
+
+    hostname_helper = '''
+def is_valid_hostname(hostname):
+    """Check if hostname is a valid DNS name (RFC 1123)."""
+    import re
+    if not hostname or len(hostname) > 253:
+        return False
+    if hostname.endswith("."):
+        hostname = hostname[:-1]
+    pattern = re.compile(r"^[a-zA-Z0-9]([a-zA-Z0-9\\-]{0,61}[a-zA-Z0-9])?$")
+    return all(pattern.match(label) for label in hostname.split("."))
+
+
+'''
+
+    # Insert helper before is_valid_single_ip
+    content = content.replace(
+        "def is_valid_single_ip(ip_string):",
+        hostname_helper + "def is_valid_single_ip(ip_string):",
+    )
+
+    # Add hostname check in is_valid_single_ip
+    content = content.replace(
+        '        elif netaddr.valid_ipv6(ip_string):\n            return True\n        return False',
+        '        elif netaddr.valid_ipv6(ip_string):\n            return True\n        elif is_valid_hostname(ip_string):\n            return True\n        return False',
+    )
+
+    with open(filepath, "w") as f:
+        f.write(content)
+
+    print(f"Patched {filepath}")
+
+
+def patch_util(base_path):
+    """Patch util.py to resolve hostnames in get_addr_port_pairs()."""
+    filepath = os.path.join(
+        base_path, "pkgs/duoauthproxy/duoauthproxy/lib/util.py"
+    )
+
+    with open(filepath, "r") as f:
+        content = f.read()
+
+    resolver_func = '''def _resolve_host(host):
+    """Resolve hostname to IP address. Pass through if already an IP."""
+    import socket
+    if netaddr.valid_ipv4(host, flags=netaddr.core.INET_PTON) or netaddr.valid_ipv6(host):
+        return host
+    try:
+        result = socket.getaddrinfo(host, None, socket.AF_UNSPEC, socket.SOCK_DGRAM)
+        if result:
+            resolved_ip = result[0][4][0]
+            log.msg("Resolved hostname '{}' to IP '{}'".format(host, resolved_ip))
+            return resolved_ip
+    except socket.gaierror as e:
+        raise ConfigError("Could not resolve hostname '{}': {}".format(host, e))
+    raise ConfigError("Could not resolve hostname '{}'".format(host))
+
+
+'''
+
+    # Insert resolver before get_addr_port_pairs
+    content = content.replace(
+        "def get_addr_port_pairs(config):",
+        resolver_func + "def get_addr_port_pairs(config):",
+    )
+
+    # Replace direct host usage with resolved host
+    content = content.replace(
+        "                config.get_str(host_key),\n"
+        '                config.get_int("port" + suffix, default_port),',
+        "                _resolve_host(config.get_str(host_key)),\n"
+        '                config.get_int("port" + suffix, default_port),',
+    )
+
+    content = content.replace(
+        "                config.get_str(host_key),\n"
+        '                config.get_int(("port_%d" % i), default_port),',
+        "                _resolve_host(config.get_str(host_key)),\n"
+        '                config.get_int(("port_%d" % i), default_port),',
+    )
+
+    with open(filepath, "w") as f:
+        f.write(content)
+
+    print(f"Patched {filepath}")
+
+
+def main():
+    if len(sys.argv) != 2:
+        print(f"Usage: {sys.argv[0]} <duoauthproxy-src-path>")
+        sys.exit(1)
+
+    base_path = sys.argv[1]
+
+    if not os.path.isdir(base_path):
+        print(f"Error: {base_path} is not a directory")
+        sys.exit(1)
+
+    patch_ip_util(base_path)
+    patch_util(base_path)
+
+    print("DNS hostname support patched successfully.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- Add optional build-time DNS patch (`ENABLE_DNS_PATCH=true`) that allows hostnames in `RADIUS_HOST`
- Patch extends `is_valid_single_ip()` to accept RFC 1123 hostnames and adds `_resolve_host()` for DNS resolution at startup
- CI builds and publishes both standard and `-dns` image variants with full security scanning
- Document DNS variant usage in README

Closes #46

## Test plan

- [ ] Build standard image without `ENABLE_DNS_PATCH` — verify hostname in `RADIUS_HOST` is rejected
- [ ] Build DNS variant with `ENABLE_DNS_PATCH=true` — verify hostname in `RADIUS_HOST` resolves correctly
- [ ] Verify CI produces both tag variants (e.g. `edge-duo6.6.0` and `edge-duo6.6.0-dns`)
- [ ] Test in Docker Compose/Swarm with service name as `RADIUS_HOST`