### PR TITLE
fix: allow underscores in DNS hostnames for Docker service names

### DIFF
--- a/assets/patch-dns-support.sh
+++ b/assets/patch-dns-support.sh
@@ -35,7 +35,7 @@ awk '
     print "        return False"
     print "    if hostname.endswith(\".\"):"
     print "        hostname = hostname[:-1]"
-    print "    pattern = re.compile(r\"^[a-zA-Z0-9]([a-zA-Z0-9\\\\-]{0,61}[a-zA-Z0-9])?$\")"
+    print "    pattern = re.compile(r\"^[a-zA-Z0-9]([a-zA-Z0-9_\\\\-]{0,61}[a-zA-Z0-9])?$\")"
     print "    return all(pattern.match(label) for label in hostname.split(\".\"))"
     print ""
     print ""


### PR DESCRIPTION
## Summary

- Extend hostname validation regex to accept underscores (`_`) in Docker service names
- Docker service names like `freeradius_primary` are not RFC 1123 compliant but are valid in Docker DNS

Closes #50

## Test plan

- [ ] Build DNS variant and test with `RADIUS_HOST=freeradius_primary` (underscore)
- [ ] Verify `freeradius-primary` (hyphen) still works
- [ ] Verify IP addresses still work