### PR TITLE
fix: add missing netaddr import in _resolve_host

### DIFF
--- a/assets/patch-dns-support.sh
+++ b/assets/patch-dns-support.sh
@@ -35,7 +35,7 @@ awk '
     print "        return False"
     print "    if hostname.endswith(\".\"):"
     print "        hostname = hostname[:-1]"
-    print "    pattern = re.compile(r\"^[a-zA-Z0-9]([a-zA-Z0-9\\\\-]{0,61}[a-zA-Z0-9])?$\")"
+    print "    pattern = re.compile(r\"^[a-zA-Z0-9]([a-zA-Z0-9_\\\\-]{0,61}[a-zA-Z0-9])?$\")"
     print "    return all(pattern.match(label) for label in hostname.split(\".\"))"
     print ""
     print ""

--- a/assets/patch-dns-support.sh
+++ b/assets/patch-dns-support.sh
@@ -64,6 +64,7 @@ awk '
     print "def _resolve_host(host):"
     print "    \"\"\"Resolve hostname to IP address. Pass through if already an IP.\"\"\""
     print "    import socket"
+    print "    import netaddr"
     print "    if netaddr.valid_ipv4(host, flags=netaddr.core.INET_PTON) or netaddr.valid_ipv6(host):"
     print "        return host"
     print "    try:"


### PR DESCRIPTION
## Summary

- Add `import netaddr` inside `_resolve_host()` in the DNS patch script
- Without this, connectivity tool fails with `NameError: name 'netaddr' is not defined`

## Test plan

- [ ] Build DNS variant image
- [ ] Start container with `RADIUS_HOST=freeradius_primary`
- [ ] Verify connectivity tool passes without NameError