### PR TITLE
feat: wait for RADIUS host DNS resolution before startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,8 @@ volumes:
 | `RADIUS_FAILMODE` | `safe` | Behavior when Duo is unreachable — `safe` (allow) or `secure` (deny) |
 | `RADIUS_PASS_THROUGH_ALL` | `false` | Forward all RADIUS attributes to the client |
 | `RADIUS_PASS_THROUGH_ATTRS` | — | Comma-separated attribute names to forward (e.g. `Framed-IP-Address,Reply-Message`) |
+| `RADIUS_HOST_WAIT_RETRIES` | `30` | Max attempts to resolve `RADIUS_HOST` before failing (useful with `-dns` variant in Swarm) |
+| `RADIUS_HOST_WAIT_INTERVAL` | `2` | Seconds between resolution attempts |
 
 ### Multiple RADIUS Servers (up to 6)
 

--- a/assets/01-init.sh
+++ b/assets/01-init.sh
@@ -67,6 +67,31 @@ validate_client_type() {
     }
 }
 
+wait_for_radius_hosts() {
+    local retries=${RADIUS_HOST_WAIT_RETRIES:-30}
+    local interval=${RADIUS_HOST_WAIT_INTERVAL:-2}
+    local hosts=("${RADIUS_HOST}")
+
+    for i in {2..6}; do
+        local host_var="RADIUS_HOST_${i}"
+        [ -n "${!host_var}" ] && hosts+=("${!host_var}")
+    done
+
+    for host in "${hosts[@]}"; do
+        local attempt=0
+        while ! getent hosts "${host}" >/dev/null 2>&1; do
+            attempt=$((attempt + 1))
+            if [ "${attempt}" -ge "${retries}" ]; then
+                log "ERROR: Could not resolve RADIUS host '${host}' after ${retries} attempts"
+                exit 1
+            fi
+            log "Waiting for RADIUS host '${host}' to become resolvable (attempt ${attempt}/${retries})..."
+            sleep "${interval}"
+        done
+        log "RADIUS host '${host}' is resolvable."
+    done
+}
+
 validate_failmode() {
     local valid_modes=("safe" "secure")
     local failmode=${RADIUS_FAILMODE:-safe}
@@ -186,6 +211,8 @@ main() {
     validate_client_type
     validate_failmode
     validate_pass_through_all_value
+
+    wait_for_radius_hosts
 
     log "Writing configuration to ${CONFIG_FILE}..."
 


### PR DESCRIPTION
## Summary

- Add `wait_for_radius_hosts()` in `01-init.sh` that retries DNS resolution for all configured RADIUS hosts before writing config and starting the proxy
- Relevant for `-dns` image variant in Docker Swarm where `RADIUS_HOST` is a service name
- Document two new optional env variables in README

| Variable | Default | Description |
| --- | --- | --- |
| `RADIUS_HOST_WAIT_RETRIES` | `30` | Max resolution attempts |
| `RADIUS_HOST_WAIT_INTERVAL` | `2` | Seconds between attempts |

With defaults, proxy waits up to 60 seconds.

Closes #54

## Test plan

- [ ] Start proxy with `RADIUS_HOST=freeradius_primary` before RADIUS service is up — verify proxy waits and retries
- [ ] Start proxy after RADIUS service is up — verify immediate startup
- [ ] Set `RADIUS_HOST_WAIT_RETRIES=3` and keep RADIUS down — verify proxy exits with clear error after 3 attempts