### PR TITLE
feat: add [main] section support with debug and logging options

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,15 @@ volumes:
 | `RADIUS_FAILMODE` | `safe` | Behavior when Duo is unreachable — `safe` (allow) or `secure` (deny) |
 | `RADIUS_PASS_THROUGH_ALL` | `false` | Forward all RADIUS attributes to the client |
 | `RADIUS_PASS_THROUGH_ATTRS` | — | Comma-separated attribute names to forward (e.g. `Framed-IP-Address,Reply-Message`) |
+| `DEBUG` | `false` | Enable debug logging (`[main]` section) |
+| `LOG_AUTH_EVENTS` | `false` | Write SIEM-consumable auth events to `authevents.log` |
+| `LOG_STDOUT` | `false` | Send logs to stdout (recommended for Docker) |
+| `LOG_DIR` | — | Directory for log files (default: `log`) |
+| `LOG_MAX_FILES` | `6` | Maximum number of rotated log files to keep |
+| `LOG_MAX_SIZE` | `10485760` | Maximum log file size in bytes |
+| `INTERFACE` | — | IP address to bind to (default: all interfaces) |
+| `HTTP_PROXY_HOST` | — | Hostname/IP of upstream HTTP proxy for Duo API communication |
+| `HTTP_PROXY_PORT` | `80` | Port for `HTTP_PROXY_HOST` |
 
 ### Multiple RADIUS Servers (up to 6)
 

--- a/assets/01-init.sh
+++ b/assets/01-init.sh
@@ -95,8 +95,30 @@ validate_required_vars() {
     done
 }
 
-write_radius_client_section() {
+write_main_section() {
     cat >"$CONFIG_FILE" <<EOF
+[main]
+EOF
+
+    local bool_val
+    for var in DEBUG LOG_AUTH_EVENTS LOG_STDOUT; do
+        bool_val=$(echo "${!var:-false}" | tr '[:upper:]' '[:lower:]')
+        [ "$bool_val" = "true" ] && echo "${var,,}=true" >>"$CONFIG_FILE"
+    done
+
+    [ -n "${LOG_DIR}" ]           && echo "log_dir=${LOG_DIR}"                     >>"$CONFIG_FILE"
+    [ -n "${LOG_MAX_FILES}" ]     && echo "log_max_files=${LOG_MAX_FILES}"         >>"$CONFIG_FILE"
+    [ -n "${LOG_MAX_SIZE}" ]      && echo "log_max_size=${LOG_MAX_SIZE}"           >>"$CONFIG_FILE"
+    [ -n "${INTERFACE}" ]         && echo "interface=${INTERFACE}"                 >>"$CONFIG_FILE"
+    [ -n "${HTTP_PROXY_HOST}" ]   && echo "http_proxy_host=${HTTP_PROXY_HOST}"     >>"$CONFIG_FILE"
+    [ -n "${HTTP_PROXY_HOST}" ] && [ -n "${HTTP_PROXY_PORT}" ] && \
+        echo "http_proxy_port=${HTTP_PROXY_PORT}"                                  >>"$CONFIG_FILE"
+
+    echo "" >>"$CONFIG_FILE"
+}
+
+write_radius_client_section() {
+    cat >>"$CONFIG_FILE" <<EOF
 [radius_client]
 host=${RADIUS_HOST}
 EOF
@@ -189,6 +211,7 @@ main() {
 
     log "Writing configuration to ${CONFIG_FILE}..."
 
+    write_main_section
     write_radius_client_section
     write_radius_server_section
 


### PR DESCRIPTION
## Summary

- Adds `write_main_section()` to generate `[main]` section at the top of `authproxy.cfg`
- Boolean options (`DEBUG`, `LOG_AUTH_EVENTS`, `LOG_STDOUT`) written only when `true`
- String/numeric options written only when set
- Documents all new env vars in README

## New Environment Variables

| Variable | Default | Description |
| --- | --- | --- |
| `DEBUG` | `false` | Enable debug logging |
| `LOG_AUTH_EVENTS` | `false` | SIEM auth events to `authevents.log` |
| `LOG_STDOUT` | `false` | Logs to stdout (recommended for Docker) |
| `LOG_DIR` | — | Log files directory |
| `LOG_MAX_FILES` | `6` | Max rotated log files |
| `LOG_MAX_SIZE` | `10485760` | Max log file size in bytes |
| `INTERFACE` | — | Bind to specific IP (useful with host networking) |
| `HTTP_PROXY_HOST` | — | Upstream HTTP proxy for Duo API |
| `HTTP_PROXY_PORT` | `80` | Port for `HTTP_PROXY_HOST` |

## Test plan

- [ ] Start container without any new vars — `[main]` section is empty (only header)
- [ ] Set `DEBUG=true` — verify `debug=true` appears in config
- [ ] Set `LOG_STDOUT=true` — verify logs appear in `docker logs`
- [ ] Set `HTTP_PROXY_HOST=proxy.example.com HTTP_PROXY_PORT=3128` — verify both lines written
- [ ] Set `HTTP_PROXY_HOST` without `HTTP_PROXY_PORT` — verify only `http_proxy_host` written

Closes #57